### PR TITLE
feat: add cal_min/cal_max/colorbar_visible reactive props

### DIFF
--- a/demo/additive_voxels.ipynb
+++ b/demo/additive_voxels.ipynb
@@ -6,25 +6,40 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!wget https://github.com/niivue/niivue/raw/main/demos/images/narps-4735_50GV-hypo1_unthresh.nii.gz -P ../images/\n",
+    "!wget https://github.com/niivue/niivue/raw/main/demos/images/narps-4965_9U7M-hypo1_unthresh.nii.gz -P ../images/\n",
+    "!wget https://github.com/niivue/niivue/raw/main/demos/images/mni152.nii.gz -P ../images/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from ipyniivue_experimental import AnyNiivue, SliceType\n",
     "# based on https://niivue.github.io/niivue/features/additive.voxels.html\n",
     "\n",
     "volumes = [\n",
-    "        { \"path\": \"../images/mni152.nii.gz\" },\n",
-    "        {\n",
-    "          \"path\": \"../images/narps-4965_9U7M-hypo1_unthresh.nii.gz\",\n",
-    "          \"colormap\": \"red\",\n",
-    "          \"cal_min\": 2,\n",
-    "          \"cal_max\": 4,\n",
-    "        },\n",
-    "        {\n",
-    "          \"path\": \"../images/narps-4735_50GV-hypo1_unthresh.nii.gz\",\n",
-    "          \"colormap\": \"green\",\n",
-    "          \"cal_min\": 2,\n",
-    "          \"cal_max\": 4,\n",
-    "        },\n",
-    "      ]\n",
-    "nv = AnyNiivue()\n",
+    "    {   \"path\": \"../images/mni152.nii.gz\" },\n",
+    "    {\n",
+    "        \"path\": \"../images/narps-4965_9U7M-hypo1_unthresh.nii.gz\",\n",
+    "        \"colormap\": \"red\",\n",
+    "        \"cal_min\": 2,\n",
+    "        \"cal_max\": 4,\n",
+    "    },\n",
+    "    {\n",
+    "        \"path\": \"../images/narps-4735_50GV-hypo1_unthresh.nii.gz\",\n",
+    "        \"colormap\": \"green\",\n",
+    "        \"cal_min\": 2,\n",
+    "        \"cal_max\": 4,\n",
+    "    },\n",
+    "]\n",
+    "nv = AnyNiivue(\n",
+    "    back_color=(1, 1, 1, 1),\n",
+    "    show_3D_crosshair=True,\n",
+    "    is_colorbar=True,\n",
+    ")\n",
     "nv.load_volumes(volumes)\n",
     "nv"
    ]
@@ -35,14 +50,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nv.volumes[0].colorbarVisible = False\n",
-    "nv.volumes[1].cal_min = 1"
+    "import ipywidgets\n",
+    "\n",
+    "nv.volumes[0].colorbar_visible = False\n",
+    "sred = ipywidgets.FloatSlider(min=0.1, max=0.4, step=0.01, value=0.2)\n",
+    "ipywidgets.link((sred, \"value\"), (nv.volumes[1], \"cal_min\"))\n",
+    "sgreen = ipywidgets.FloatSlider(min=0.1, max=0.4, step=0.01, value=0.2)\n",
+    "ipywidgets.link((sgreen, \"value\"), (nv.volumes[2], \"cal_min\"))\n",
+    "ipywidgets.HBox([sred, sgreen])"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -56,9 +84,16 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.12.1"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/js/types.ts
+++ b/js/types.ts
@@ -4,6 +4,10 @@ export type VolumeModel = { model_id: string } & AnyModel<{
 	path: { name: string; data: DataView };
 	colormap: string;
 	opacity: number;
+    colorbar_visible: boolean;
+	cal_min?: number;
+	cal_max?: number;
+	visible: boolean;
 }>;
 
 export type Model = AnyModel<{

--- a/js/types.ts
+++ b/js/types.ts
@@ -7,7 +7,6 @@ export type VolumeModel = { model_id: string } & AnyModel<{
     colorbar_visible: boolean;
 	cal_min?: number;
 	cal_max?: number;
-	visible: boolean;
 }>;
 
 export type Model = AnyModel<{

--- a/js/widget.js
+++ b/js/widget.js
@@ -83,7 +83,7 @@ function create_volume(nv, vmodel) {
     undefined,                      // trustMinCalMinMax
     undefined,                      // percentileFrac
     undefined,                      // ignoreZeroVoxels
-    vmodel.get("visible"),          // visible
+    undefined,                      // visible
     undefined,                      // useQFormNotSForm
     undefined,                      // colormapNegative
     undefined,                      // frame4D
@@ -105,11 +105,6 @@ function create_volume(nv, vmodel) {
     volume.cal_min = vmodel.get("cal_min");
     nv.updateGLVolume();
   }
-  // NOTE: I don't think this does anything
-  function visible_changed() {
-    volume.visible = vmodel.get("visible");
-    nv.updateGLVolume();
-  }
   function colormap_changed() {
     volume.colormap = vmodel.get("colormap");
     nv.updateGLVolume();
@@ -121,14 +116,12 @@ function create_volume(nv, vmodel) {
   vmodel.on("change:colorbar_visible", colorbar_visible_changed);
   vmodel.on("change:cal_min", cal_min_changed);
   vmodel.on("change:cal_max", cal_max_changed);
-  vmodel.on("change:visible", visible_changed);
   vmodel.on("change:colormap", colormap_changed);
   vmodel.on("change:opacity", opacity_changed);
   return [volume, () => {
     vmodel.off("change:colorbar_visible", colorbar_visible_changed);
     vmodel.off("change:cal_min", cal_min_changed);
     vmodel.off("change:cal_max", cal_max_changed);
-    vmodel.off("change:visible", visible_changed);
     vmodel.off("change:colormap", colormap_changed);
     vmodel.off("change:opacity", opacity_changed);
   }]

--- a/js/widget.js
+++ b/js/widget.js
@@ -73,21 +73,62 @@ function gather_volume_models(model) {
  */
 function create_volume(nv, vmodel) {
   let volume = new NVImage(
-    vmodel.get("path").data.buffer,
-    volume_id(vmodel),
-    vmodel.get("colormap"),
-    vmodel.get("opacity"),
+    vmodel.get("path").data.buffer, // dataBuffer
+    volume_id(vmodel),              // name
+    vmodel.get("colormap"),         // colormap
+    vmodel.get("opacity"),          // opacity
+    undefined,                      // pairedImgData
+    vmodel.get("cal_min"),          // cal_min
+    vmodel.get("cal_max"),          // cal_max
+    undefined,                      // trustMinCalMinMax
+    undefined,                      // percentileFrac
+    undefined,                      // ignoreZeroVoxels
+    vmodel.get("visible"),          // visible
+    undefined,                      // useQFormNotSForm
+    undefined,                      // colormapNegative
+    undefined,                      // frame4D
+    undefined,                      // imageType
+    undefined,                      // cal_minNeg
+    undefined,                      // cal_maxNeg
+    vmodel.get("colorbar_visible"), // colorbarVisible
+    undefined,                      // colormapLabel
   );
+  function colorbar_visible_changed() {
+    volume.colorbarVisible = vmodel.get("colorbar_visible");
+    nv.updateGLVolume();
+  }
+  function cal_min_changed() {
+    volume.cal_min = vmodel.get("cal_min");
+    nv.updateGLVolume();
+  }
+  function cal_max_changed() {
+    volume.cal_min = vmodel.get("cal_min");
+    nv.updateGLVolume();
+  }
+  // NOTE: I don't think this does anything
+  function visible_changed() {
+    volume.visible = vmodel.get("visible");
+    nv.updateGLVolume();
+  }
   function colormap_changed() {
-    nv.setColormap(volume.id, vmodel.get("colormap"));
+    volume.colormap = vmodel.get("colormap");
+    nv.updateGLVolume();
   }
   function opacity_changed() {
-    let idx = nv.volumes.findIndex(v => v === volume);
-    nv.setOpacity(idx, vmodel.get("opacity"));
+    volume.opacity = vmodel.get("opacity");
+    nv.updateGLVolume();
   }
+  vmodel.on("change:colorbar_visible", colorbar_visible_changed);
+  vmodel.on("change:cal_min", cal_min_changed);
+  vmodel.on("change:cal_max", cal_max_changed);
+  vmodel.on("change:visible", visible_changed);
   vmodel.on("change:colormap", colormap_changed);
   vmodel.on("change:opacity", opacity_changed);
   return [volume, () => {
+    vmodel.off("change:colorbar_visible", colorbar_visible_changed);
+    vmodel.off("change:cal_min", cal_min_changed);
+    vmodel.off("change:cal_max", cal_max_changed);
+    vmodel.off("change:visible", visible_changed);
     vmodel.off("change:colormap", colormap_changed);
     vmodel.off("change:opacity", opacity_changed);
   }]

--- a/src/ipyniivue_experimental/_widget.py
+++ b/src/ipyniivue_experimental/_widget.py
@@ -19,7 +19,6 @@ class Volume(ipywidgets.Widget):
     colorbar_visible = t.Bool(True).tag(sync=True)
     cal_min = t.Float(None, allow_none=True).tag(sync=True)
     cal_max = t.Float(None, allow_none=True).tag(sync=True)
-    visible = t.Bool(True).tag(sync=True)
 
 
 class AnyNiivue(OptionsMixin, anywidget.AnyWidget):

--- a/src/ipyniivue_experimental/_widget.py
+++ b/src/ipyniivue_experimental/_widget.py
@@ -16,6 +16,10 @@ class Volume(ipywidgets.Widget):
     )
     opacity = t.Float(1.0).tag(sync=True)
     colormap = t.Unicode("gray").tag(sync=True)
+    colorbar_visible = t.Bool(True).tag(sync=True)
+    cal_min = t.Float(None, allow_none=True).tag(sync=True)
+    cal_max = t.Float(None, allow_none=True).tag(sync=True)
+    visible = t.Bool(True).tag(sync=True)
 
 
 class AnyNiivue(OptionsMixin, anywidget.AnyWidget):


### PR DESCRIPTION
```py
from ipyniivue_experimental import AnyNiivue, SliceType
# based on https://niivue.github.io/niivue/features/additive.voxels.html

volumes = [
    {   "path": "../images/mni152.nii.gz" },
    {
        "path": "../images/narps-4965_9U7M-hypo1_unthresh.nii.gz",
        "colormap": "red",
        "cal_min": 2,
        "cal_max": 4,
    },
    {
        "path": "../images/narps-4735_50GV-hypo1_unthresh.nii.gz",
        "colormap": "green",
        "cal_min": 2,
        "cal_max": 4,
    },
]
nv = AnyNiivue(
    back_color=(1, 1, 1, 1),
    show_3D_crosshair=True,
    is_colorbar=True,
)
nv.load_volumes(volumes)
nv
```

```py
import ipywidgets

nv.volumes[0].colorbar_visible = False
sred = ipywidgets.FloatSlider(min=0.1, max=0.4, step=0.01, value=0.2)
ipywidgets.link((sred, "value"), (nv.volumes[1], "cal_min"))
sgreen = ipywidgets.FloatSlider(min=0.1, max=0.4, step=0.01, value=0.2)
ipywidgets.link((sgreen, "value"), (nv.volumes[2], "cal_min"))
ipywidgets.HBox([sred, sgreen])
```